### PR TITLE
Sysctl inotify max_user_watches check/modify on install, desktop_dir defined in defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,4 +13,7 @@ root_dir: "{{role_path}}"
 deploy_user: "{{ansible_user_id}}"
 apps_dir: "/home/{{ansible_user_id}}/apps"
 
+desktop_dir: "Desktop"
 
+sysctl_conf_lines:
+  - { name: 'fs.inotify.max_user_watches', value: '524288' }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ option_install_java: false
 
 java_version: 7
 
-pycharm_version: "2016.2" #"2016.1.4" #"2016.1" #5.0.1 # 4.5.4
+pycharm_version: "2016.2.1" #"2016.2" #"2016.1.4" #"2016.1" #5.0.1 # 4.5.4
 pycharm_edition: community # professional | community
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,5 @@
     when: option_install_java
 
   - include: tasks_jetbrains_pycharm_community.yml
+
+  - include: tasks_sysctl.yml

--- a/tasks/tasks_jetbrains_pycharm_community.yml
+++ b/tasks/tasks_jetbrains_pycharm_community.yml
@@ -79,7 +79,7 @@
   - name: JetBrains PyCharm| Create desktop entry
     template:
       src={{root_dir}}/files/jetbrains/desktopentry.j2
-      dest=/home/{{deploy_user}}/Desktop/PyCharm.desktop
+      dest=/home/{{deploy_user}}/{{desktop_dir}}/PyCharm.desktop
       mode=755
     with_items:
       - {

--- a/tasks/tasks_jetbrains_pycharm_community.yml
+++ b/tasks/tasks_jetbrains_pycharm_community.yml
@@ -16,7 +16,7 @@
 
   - name: JetBrains Pycharm| Check pycharm_version variable
     assert:
-      that: pycharm_version in ["2016.4", "2016.3", "2016.2", "2016.1.4", "2016.1", "5.0.1", "4.5.4"]
+      that: pycharm_version in ["2016.4", "2016.3", "2016.2.1", "2016.2", "2016.1.4", "2016.1", "5.0.1", "4.5.4"]
     tags:
       -jetbrains
       -pycharm

--- a/tasks/tasks_sysctl.yml
+++ b/tasks/tasks_sysctl.yml
@@ -1,0 +1,7 @@
+  - name: SETTINGS | keys in sysctl.conf
+    sysctl: name={{item.name}} value={{item.value}} ignoreerrors=yes state={{item.state | default('present')}}
+    with_items: "{{ sysctl_conf_lines | default()}}"
+    become: yes
+    tags:
+      - settings
+      - sysctl


### PR DESCRIPTION
Changes:
1. On non-English Ubuntu directory Desktop is not Desktop
2. Inotify limit increased to work faster with PyCharm
Sources:
- hint in PyCharm
- https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit
